### PR TITLE
Add new API for prompts with CRUD operations

### DIFF
--- a/worker/src/api/prompts.schema.ts
+++ b/worker/src/api/prompts.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+import { recommendedModel } from "./models.schema"
+
+export const promptSchema = z.object({
+  name: z.string().openapi({ description: "Name of the prompt", example: "explain" }),
+  description: z.string().openapi({ description: "Description of the prompt.", example: "explain content ...." }),
+  model: z.string().openapi({ description: "Model used for the prompt. For more details, visit https://developers.cloudflare.com/workers-ai/models/", example: recommendedModel.cfName }),
+  messages: z.array(z.object({
+    role: z.string().openapi({ description: "Role of the message", example: "system" }),
+    content: z.string().openapi({ description: "Content of the message", example: "..." })
+  })).openapi({ description: "Messages in the prompt" })
+})

--- a/worker/src/api/prompts.ts
+++ b/worker/src/api/prompts.ts
@@ -1,0 +1,119 @@
+import { Hono } from "hono"
+import { zValidator } from "@hono/zod-validator"
+import { promptSchema } from "./prompts.schema"
+import { v4 as uuidv4 } from 'uuid'
+import { describeRoute } from "hono-openapi"
+import { resolver } from "hono-openapi/zod"
+
+const prompts = new Hono<{ Bindings: CloudflareEnv }>()
+
+prompts.get("/api/prompts/:key",
+  describeRoute({
+    description: "Get a prompt by key",
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: resolver(promptSchema)
+          }
+        }
+      }
+    }
+  }),
+  async (c) => {
+    const key = c.req.param("key")
+    const prompt = await c.env.prompts.get(key)
+    if (!prompt) {
+      return c.json({ error: "Prompt not found" }, 404)
+    }
+    return c.json(JSON.parse(prompt))
+  }
+)
+
+prompts.put("/api/prompts/:key",
+  describeRoute({
+    description: "Update a prompt by key",
+    requestBody: {
+      content: {
+        "application/json": {
+          schema: resolver(promptSchema)
+        }
+      }
+    },
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: resolver(promptSchema)
+          }
+        }
+      }
+    }
+  }),
+  zValidator("json", promptSchema),
+  async (c) => {
+    const key = c.req.param("key")
+    const prompt = await c.req.json()
+    const promptSize = new TextEncoder().encode(JSON.stringify(prompt)).length
+    if (promptSize > 25 * 1024 * 1024) {
+      return c.json({ error: "Prompt size exceeds 25MB limit" }, 400)
+    }
+    await c.env.prompts.put(key, JSON.stringify(prompt))
+    return c.json(prompt)
+  }
+)
+
+prompts.post("/api/prompts",
+  describeRoute({
+    description: "Create a new prompt",
+    requestBody: {
+      content: {
+        "application/json": {
+          schema: resolver(promptSchema)
+        }
+      }
+    },
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: resolver(promptSchema)
+          }
+        }
+      }
+    }
+  }),
+  zValidator("json", promptSchema),
+  async (c) => {
+    const key = uuidv4()
+    const prompt = await c.req.json()
+    const promptSize = new TextEncoder().encode(JSON.stringify(prompt)).length
+    if (promptSize > 25 * 1024 * 1024) {
+      return c.json({ error: "Prompt size exceeds 25MB limit" }, 400)
+    }
+    await c.env.prompts.put(key, JSON.stringify(prompt))
+    return c.json({ success: true, key, prompt })
+  }
+)
+
+prompts.delete("/api/prompts/:key",
+  describeRoute({
+    description: "Delete a prompt by key",
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            schema: resolver(promptSchema)
+          }
+        }
+      }
+    }
+  }),
+  async (c) => {
+    const key = c.req.param("key")
+    await c.env.prompts.delete(key)
+    return c.json({ success: true })
+  }
+)
+
+export default prompts

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -8,6 +8,7 @@ import codeReview from "./api/code-review"
 import health from "./api/health"
 import models from "./api/models"
 import auth from "./middleware/auth"
+import prompts from "./api/prompts"
 
 const app = new Hono<{ Bindings: CloudflareEnv }>()
 
@@ -16,6 +17,7 @@ app.route("/health", health)
 
 app.route("/api/code-review", codeReview)
 app.route("/api/public/models", models)
+app.route("/api/prompts", prompts)
 
 const appName = "Cloudflare AI code review worker"
 app.get("/schemas", openAPISpecs(app, {


### PR DESCRIPTION
Add new API endpoints for managing prompts stored in Cloudflare KV.

* **Define Prompt Schema**: Add `worker/src/api/prompts.schema.ts` to define a Zod schema for the prompt object, including `name`, `description`, `model`, and `messages` fields.
* **Implement Prompts API**: Add `worker/src/api/prompts.ts` to create a new Hono instance for the prompts API with GET, PUT, POST, DELETE methods for `/api/prompts/:key`. Use the prompts schema for validation, interact with Cloudflare KV to store and retrieve prompts, verify each method's KV value does not exceed 25MB, generate a UUID as KV key for each value, and return KV value after PUT and POST.
* **Route Prompts API**: Modify `worker/src/index.ts` to import and route the new prompts API, adding a route for `/api/prompts`.

