### PR TITLE
Add PromptCard component to display prompts

### DIFF
--- a/code-review-admin/app/page.tsx
+++ b/code-review-admin/app/page.tsx
@@ -2,6 +2,7 @@ import { Container } from "@mui/material"
 
 import Login2Github from "@/src/components/Login2Github"
 import ToggleTheme from "@/src/components/ToggleTheme"
+import PromptList from "@/src/components/PromptList"
 
 export default function Home() {
     return (
@@ -12,6 +13,7 @@ export default function Home() {
                 <ToggleTheme />
                 <Login2Github />
             </div>
+            <PromptList />
         </Container>
     )
 }

--- a/code-review-admin/src/components/PromptCard.tsx
+++ b/code-review-admin/src/components/PromptCard.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, Typography } from "@mui/material"
+
+type Prompt = {
+    name: string
+    description: string
+    messages: { role: string, content: string }[]
+}
+
+type PromptCardProps = {
+    prompt: Prompt
+}
+
+const PromptCard = ({ prompt }: PromptCardProps) => {
+    return (
+        <Card>
+            <CardContent>
+                <Typography variant="h5" component="div">
+                    {prompt.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                    {prompt.description}
+                </Typography>
+                {prompt.messages.map((message, index) => (
+                    <Typography
+                        key={index}
+                        variant="body2"
+                        color="text.secondary"
+                        style={{
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis"
+                        }}
+                    >
+                        {message.content}
+                    </Typography>
+                ))}
+            </CardContent>
+        </Card>
+    )
+}
+
+export default PromptCard

--- a/code-review-admin/src/components/PromptList.tsx
+++ b/code-review-admin/src/components/PromptList.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import PromptCard from "@/src/components/PromptCard"
+
+const PromptList = () => {
+    const [prompts, setPrompts] = useState([])
+
+    useEffect(() => {
+        async function fetchPrompts() {
+            const response = await fetch(process.env.API_URL + "/api/prompts")
+            const data = await response.json()
+            setPrompts(data.prompts)
+        }
+
+        fetchPrompts()
+    }, [])
+
+    return (
+        <div>
+            {prompts.map((prompt) => (
+                <PromptCard key={prompt.name} prompt={prompt} />
+            ))}
+        </div>
+    )
+}
+
+export default PromptList

--- a/code-review-admin/src/utils/prompts.ts
+++ b/code-review-admin/src/utils/prompts.ts
@@ -1,0 +1,6 @@
+export interface Prompt {
+    name: string
+    description: string
+    model: string
+    messages: { role: string, content: string }[]
+}


### PR DESCRIPTION
Add a list card to preview prompts on the home page.

* **Home Page**: Import and render `PromptList` component in `code-review-admin/app/page.tsx`.
* **PromptCard Component**: Create `PromptCard` component in `code-review-admin/src/components/PromptCard.tsx` to display prompt details. Import `Card`, `CardContent`, and `Typography` from `@mui/material`. Define `PromptCard` component to accept a `prompt` prop and render the `Card` component with the prompt's name, description, and messages. Hide long messages as eclipsed.
* **Prompt Interface**: Define `Prompt` interface in `code-review-admin/src/utils/prompts.ts`.
* **PromptList Component**: Create `PromptList` component in `code-review-admin/src/components/PromptList.tsx`. Fetch data from the API based on the "API_URL" environment variable and render each prompt using `PromptCard`.

