### PR TITLE
Add and update prompt dialog

### DIFF
--- a/code-review-admin/src/actions/prompts.ts
+++ b/code-review-admin/src/actions/prompts.ts
@@ -1,9 +1,33 @@
 "use server"
 
+import type { Prompt } from "@/src/utils/prompts"
+
 export const getPrompts = async () => {
     return fetch(`${process.env.API_URL}/api/prompts`, {
         headers: {
             Authorization: `Bearer ${process.env.AUTH_TOKEN}`
         }
+    }).then(res => res.json())
+}
+
+export const createPrompt = async (prompt: Prompt) => {
+    return fetch(`${process.env.API_URL}/api/prompts`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${process.env.AUTH_TOKEN}`,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(prompt)
+    }).then(res => res.json())
+}
+
+export const updatePrompt = async (prompt: Partial<Prompt>) => {
+    return fetch(`${process.env.API_URL}/api/prompts/${prompt.name}`, {
+        method: "PUT",
+        headers: {
+            Authorization: `Bearer ${process.env.AUTH_TOKEN}`,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(prompt)
     }).then(res => res.json())
 }

--- a/code-review-admin/src/components/ModifyPromptDialog.tsx
+++ b/code-review-admin/src/components/ModifyPromptDialog.tsx
@@ -1,0 +1,139 @@
+import { useState, useEffect } from "react"
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, IconButton, Select, MenuItem, FormControl, InputLabel } from "@mui/material"
+import AddIcon from "@mui/icons-material/Add"
+import DeleteIcon from "@mui/icons-material/Delete"
+import { useForm, useFieldArray, Controller } from "react-hook-form"
+
+import { createPrompt, updatePrompt } from "@/src/actions/prompts"
+import type { Prompt } from "@/src/utils/prompts"
+
+type ModifyPromptDialogProps = {
+    open: boolean
+    onClose: () => void
+    prompt?: Prompt
+}
+
+const ModifyPromptDialog = ({ open, onClose, prompt }: ModifyPromptDialogProps) => {
+    const { control, handleSubmit, reset } = useForm({
+        defaultValues: {
+            name: prompt?.name || "",
+            description: prompt?.description || "",
+            model: prompt?.model || "",
+            messages: prompt?.messages || [{ role: "system", content: "" }]
+        }
+    })
+
+    const { fields, append, remove } = useFieldArray({
+        control,
+        name: "messages"
+    })
+
+    useEffect(() => {
+        if (prompt) {
+            reset({
+                name: prompt.name,
+                description: prompt.description,
+                model: prompt.model,
+                messages: prompt.messages
+            })
+        }
+    }, [prompt, reset])
+
+    const onSubmit = async (data: any) => {
+        if (prompt) {
+            await updatePrompt(data)
+        } else {
+            await createPrompt(data)
+        }
+        onClose()
+    }
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle>{prompt ? "Update Prompt" : "Add Prompt"}</DialogTitle>
+            <DialogContent>
+                <Controller
+                    name="name"
+                    control={control}
+                    render={({ field }) => (
+                        <TextField
+                            {...field}
+                            label="Name"
+                            fullWidth
+                            margin="normal"
+                        />
+                    )}
+                />
+                <Controller
+                    name="description"
+                    control={control}
+                    render={({ field }) => (
+                        <TextField
+                            {...field}
+                            label="Description"
+                            fullWidth
+                            margin="normal"
+                        />
+                    )}
+                />
+                <Controller
+                    name="model"
+                    control={control}
+                    render={({ field }) => (
+                        <TextField
+                            {...field}
+                            label="Model"
+                            fullWidth
+                            margin="normal"
+                        />
+                    )}
+                />
+                {fields.map((field, index) => (
+                    <div key={field.id} className="flex items-center gap-2">
+                        <Controller
+                            name={`messages.${index}.role`}
+                            control={control}
+                            render={({ field }) => (
+                                <FormControl fullWidth margin="normal">
+                                    <InputLabel>Role</InputLabel>
+                                    <Select
+                                        {...field}
+                                    >
+                                        <MenuItem value="system">System</MenuItem>
+                                        <MenuItem value="user">User</MenuItem>
+                                    </Select>
+                                </FormControl>
+                            )}
+                        />
+                        <Controller
+                            name={`messages.${index}.content`}
+                            control={control}
+                            render={({ field }) => (
+                                <TextField
+                                    {...field}
+                                    label="Content"
+                                    fullWidth
+                                    margin="normal"
+                                />
+                            )}
+                        />
+                        <IconButton onClick={() => remove(index)}>
+                            <DeleteIcon />
+                        </IconButton>
+                    </div>
+                ))}
+                <Button onClick={() => append({ role: "system", content: "" })} startIcon={<AddIcon />}>
+                    Add Message
+                </Button>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Cancel</Button>
+                <Button onClick={handleSubmit(onSubmit)} color="primary">
+                    {prompt ? "Update" : "Add"}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default ModifyPromptDialog

--- a/code-review-admin/src/components/PromptCard.tsx
+++ b/code-review-admin/src/components/PromptCard.tsx
@@ -4,6 +4,9 @@ import SettingsSuggestIcon from "@mui/icons-material/SettingsSuggest"
 import TipsAndUpdatesIcon from "@mui/icons-material/TipsAndUpdates"
 import { Card, CardContent, IconButton, Typography } from "@mui/material"
 import { useSession } from "next-auth/react"
+import { useState } from "react"
+
+import ModifyPromptDialog from "@/src/components/ModifyPromptDialog"
 
 type Prompt = {
     name: string
@@ -17,13 +20,18 @@ type PromptCardProps = {
 
 const PromptCard = ({ prompt }: PromptCardProps) => {
     const { data: session } = useSession()
+    const [open, setOpen] = useState(false)
+
+    const handleOpen = () => setOpen(true)
+    const handleClose = () => setOpen(false)
+
     return (
         <Card>
             <CardContent className={"relative"}>
                 {session?.user ?
                     <div className={"absolute right-0 top-0"}>
                         <IconButton color={"error"}><DeleteForeverIcon /></IconButton>
-                        <IconButton><SettingsIcon/></IconButton>
+                        <IconButton onClick={handleOpen}><SettingsIcon/></IconButton>
                     </div>
                     : null
                 }
@@ -50,6 +58,7 @@ const PromptCard = ({ prompt }: PromptCardProps) => {
                     </Typography>
                 ))}
             </CardContent>
+            <ModifyPromptDialog open={open} onClose={handleClose} prompt={prompt} />
         </Card>
     )
 }

--- a/code-review-admin/src/components/PromptList.tsx
+++ b/code-review-admin/src/components/PromptList.tsx
@@ -1,13 +1,16 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { Button } from "@mui/material"
 
 import { getPrompts } from "@/src/actions/prompts"
 import PromptCard from "@/src/components/PromptCard"
+import ModifyPromptDialog from "@/src/components/ModifyPromptDialog"
 import type { Prompt } from "@/src/utils/prompts"
 
 const PromptList = () => {
     const [prompts, setPrompts] = useState<Prompt[]>([])
+    const [open, setOpen] = useState(false)
 
     useEffect(() => {
         getPrompts().then(result => {
@@ -15,11 +18,16 @@ const PromptList = () => {
         })
     }, [])
 
+    const handleOpen = () => setOpen(true)
+    const handleClose = () => setOpen(false)
+
     return (
         <div>
+            <Button onClick={handleOpen}>Add Prompt</Button>
             {prompts.map((prompt) => (
                 <PromptCard key={prompt.name} prompt={prompt}/>
             ))}
+            <ModifyPromptDialog open={open} onClose={handleClose} />
         </div>
     )
 }


### PR DESCRIPTION
Add functionality to add and update prompts.

* **ModifyPromptDialog Component**: Create a new component `ModifyPromptDialog` to handle adding and updating prompts. Add a form with fields for name, description, model, and messages using `react-hook-form`. Add logic to handle multiple roles with system/user. Add logic to determine if the action is to create or update based on the presence of the prompt prop.
* **PromptCard Component**: Add a button to open `ModifyPromptDialog` for updating the prompt.
* **PromptList Component**: Add a button to open `ModifyPromptDialog` for adding a new prompt.
* **Prompts Actions**: Add `createPrompt` function to send a POST request to the API to create a new prompt. Add `updatePrompt` function to send a PUT request to the API to update an existing prompt.

