### PR TITLE
Add delete feature for PromptCard

### DIFF
--- a/code-review-admin/src/actions/prompts.ts
+++ b/code-review-admin/src/actions/prompts.ts
@@ -23,3 +23,10 @@ export const updatePrompt = async (prompt: Partial<Prompt>) => {
         body: JSON.stringify(prompt)
     }).then(res => res.json())
 }
+
+export const deletePrompt = async (promptName: string) => {
+    return fetch(`${process.env.API_URL}/api/prompts/${promptName}`, {
+        method: "DELETE",
+        headers: commonHeaders
+    }).then(res => res.json())
+}

--- a/code-review-admin/src/components/ConfirmDeletePromptDialog.tsx
+++ b/code-review-admin/src/components/ConfirmDeletePromptDialog.tsx
@@ -1,0 +1,37 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material"
+import { deletePrompt } from "@/src/actions/prompts"
+import type { Prompt } from "@/src/utils/prompts"
+
+type ConfirmDeletePromptDialogProps = {
+    open: boolean
+    onClose: () => void
+    onFetch: () => void
+    prompt?: Prompt
+}
+
+const ConfirmDeletePromptDialog = ({
+    open, onClose, onFetch, prompt
+}: ConfirmDeletePromptDialogProps) => {
+    const handleDelete = async () => {
+        if (prompt) {
+            await deletePrompt(prompt.name)
+            onFetch()
+            onClose()
+        }
+    }
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle>Confirm Delete</DialogTitle>
+            <DialogContent>
+                Are you sure you want to delete the prompt "{prompt?.name}"?
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color="inherit">Cancel</Button>
+                <Button onClick={handleDelete} color="error">Delete</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default ConfirmDeletePromptDialog

--- a/code-review-admin/src/components/ModifyPromptDialog.tsx
+++ b/code-review-admin/src/components/ModifyPromptDialog.tsx
@@ -13,11 +13,12 @@ import {
     Select,
     TextField
 } from "@mui/material"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Controller, useFieldArray, useForm } from "react-hook-form"
 
 import { createPrompt, updatePrompt } from "@/src/actions/prompts"
 import type { Prompt } from "@/src/utils/prompts"
+import ConfirmDeletePromptDialog from "@/src/components/ConfirmDeletePromptDialog"
 
 type ModifyPromptDialogProps = {
     prompt?: Prompt
@@ -63,6 +64,8 @@ const ModifyPromptDialog = ({
         onFetch()
         onClose()
     }
+
+    const [confirmOpen, setConfirmOpen] = useState(false)
 
     return (
         <Dialog open={open} onClose={onClose}>
@@ -121,11 +124,22 @@ const ModifyPromptDialog = ({
                 </Button>
             </DialogContent>
             <DialogActions>
+                {prompt && (
+                    <Button onClick={() => setConfirmOpen(true)} color="error">
+                        Delete
+                    </Button>
+                )}
                 <Button onClick={onClose} color={"inherit"}>Cancel</Button>
                 <Button onClick={handleSubmit(onSubmit)} color="primary">
                     {prompt ? "Update" : "Add"}
                 </Button>
             </DialogActions>
+            <ConfirmDeletePromptDialog
+                open={confirmOpen}
+                onClose={() => setConfirmOpen(false)}
+                onFetch={onFetch}
+                prompt={prompt}
+            />
         </Dialog>
     )
 }

--- a/code-review-admin/src/components/PromptCard.tsx
+++ b/code-review-admin/src/components/PromptCard.tsx
@@ -7,6 +7,7 @@ import { useSession } from "next-auth/react"
 import { useState } from "react"
 
 import ModifyPromptDialog from "@/src/components/ModifyPromptDialog"
+import ConfirmDeletePromptDialog from "@/src/components/ConfirmDeletePromptDialog"
 import type { Prompt } from "@/src/utils/prompts"
 
 type PromptCardProps = {
@@ -17,6 +18,7 @@ type PromptCardProps = {
 const PromptCard = ({ prompt, onFetch }: PromptCardProps) => {
     const { data: session } = useSession()
     const [open, setOpen] = useState(false)
+    const [confirmOpen, setConfirmOpen] = useState(false)
 
     const handleOpen = () => setOpen(true)
     const handleClose = () => setOpen(false)
@@ -25,9 +27,15 @@ const PromptCard = ({ prompt, onFetch }: PromptCardProps) => {
         <Card>
             <CardContent className={"relative"}>
                 <ModifyPromptDialog open={open} onClose={handleClose} prompt={prompt} onFetch={onFetch}/>
+                <ConfirmDeletePromptDialog
+                    open={confirmOpen}
+                    onClose={() => setConfirmOpen(false)}
+                    onFetch={onFetch}
+                    prompt={prompt}
+                />
                 {session?.user ?
                     <div className={"absolute right-0 top-0"}>
-                        <IconButton color={"error"}><DeleteForeverIcon /></IconButton>
+                        <IconButton color={"error"} onClick={() => setConfirmOpen(true)}><DeleteForeverIcon /></IconButton>
                         <IconButton onClick={handleOpen}><SettingsIcon/></IconButton>
                     </div>
                     : null


### PR DESCRIPTION
Add delete feature for PromptCard.

* **Add `deletePrompt` function**: Add a new `deletePrompt` function in `code-review-admin/src/actions/prompts.ts` to delete a prompt by name using the DELETE method.
* **Create `ConfirmDeletePromptDialog` component**: Add a new component `ConfirmDeletePromptDialog` in `code-review-admin/src/components/ConfirmDeletePromptDialog.tsx` to show a confirmation dialog for deleting a prompt. Add props `open`, `onClose`, `onFetch`, and `prompt` to handle dialog state and actions.
* **Modify `ModifyPromptDialog` component**: Add a new button to trigger the delete action and use `ConfirmDeletePromptDialog` in `code-review-admin/src/components/ModifyPromptDialog.tsx`.
* **Update `PromptCard` component**: Show `ConfirmDeletePromptDialog` and pass `onFetch` prop to `ConfirmDeletePromptDialog` in `code-review-admin/src/components/PromptCard.tsx`.

