### PR TITLE
Split route into '/' and '/models' & display cloudflare avaliable models

### DIFF
--- a/code-review-admin/app/layout.tsx
+++ b/code-review-admin/app/layout.tsx
@@ -5,8 +5,11 @@ import type { Metadata } from "next"
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter"
 import { SessionProvider } from "next-auth/react"
 import React from "react"
+import Link from "next/link"
 
 import ClientThemeProvider from "@/src/components/ClientThemeProvider"
+import Login2Github from "@/src/components/Login2Github"
+import ToggleTheme from "@/src/components/ToggleTheme"
 
 export const metadata: Metadata = {
     title: "AI code reviewer",
@@ -20,6 +23,16 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
                 <SessionProvider>
                     <AppRouterCacheProvider>
                         <ClientThemeProvider>
+                            <div className={"flex items-center"}>
+                                Cloudflare AI Code Review
+                                <div className={"flex-1"} />
+                                <nav>
+                                    <Link href="/">Home</Link>
+                                    <Link href="/models">Models</Link>
+                                </nav>
+                                <ToggleTheme />
+                                <Login2Github />
+                            </div>
                             {children}
                         </ClientThemeProvider>
                     </AppRouterCacheProvider>

--- a/code-review-admin/app/models/page.tsx
+++ b/code-review-admin/app/models/page.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react"
+
+import { getModels } from "@/src/actions/models"
+import ModelCard from "@/src/components/ModelCard"
+
+export default function ModelsPage() {
+    const [models, setModels] = useState([])
+
+    useEffect(() => {
+        getModels().then(result => {
+            setModels(result.models)
+        })
+    }, [])
+
+    return (
+        <div className={"flex flex-wrap gap-4"}>
+            {models.map((model) => (
+                <ModelCard key={model.id} model={model} />
+            ))}
+        </div>
+    )
+}

--- a/code-review-admin/app/page.tsx
+++ b/code-review-admin/app/page.tsx
@@ -1,18 +1,9 @@
 import { Container } from "@mui/material"
-
-import Login2Github from "@/src/components/Login2Github"
 import PromptList from "@/src/components/PromptList"
-import ToggleTheme from "@/src/components/ToggleTheme"
 
 export default function Home() {
     return (
         <Container maxWidth={"sm"}>
-            <div className={"flex items-center"}>
-                Cloudflare AI Code Review
-                <div className={"flex-1"} />
-                <ToggleTheme />
-                <Login2Github />
-            </div>
             <PromptList />
         </Container>
     )

--- a/code-review-admin/src/actions/models.ts
+++ b/code-review-admin/src/actions/models.ts
@@ -1,0 +1,24 @@
+"use server"
+
+export const getModels = async (search = "", page = 1, per_page = 10): Promise<{
+    models: {
+        id: string
+        name: string
+        description: string
+        task: {
+            id: string
+            name: string
+            description: string
+        }
+    }[]
+    result_info: {
+        page: number
+        per_page: number
+        total_pages: number
+        count: number
+        total_count: number
+    }
+}> => {
+    const query = new URLSearchParams({ search, page: page.toString(), per_page: per_page.toString() })
+    return fetch(`${process.env.API_URL}/api/public/models?${query.toString()}`).then(res => res.json())
+}

--- a/code-review-admin/src/components/ModelCard.tsx
+++ b/code-review-admin/src/components/ModelCard.tsx
@@ -1,0 +1,19 @@
+import { Card, CardContent, Typography, Chip } from "@mui/material"
+import { Model } from "@/src/utils/models"
+
+type ModelCardProps = {
+    model: Model
+}
+
+export default function ModelCard({ model }: ModelCardProps) {
+    return (
+        <Card key={model.id} style={{ width: "100%", maxWidth: "300px" }}>
+            <CardContent>
+                <Typography variant="h5" component="div">{model.name}</Typography>
+                <Typography variant="body2" color="text.secondary">{model.description}</Typography>
+                <Chip label={model.task.name} style={{ marginTop: "8px" }} />
+                <Typography variant="body2" color="text.secondary" style={{ marginTop: "8px" }}>{model.task.description}</Typography>
+            </CardContent>
+        </Card>
+    )
+}

--- a/code-review-admin/src/components/ModelList.tsx
+++ b/code-review-admin/src/components/ModelList.tsx
@@ -1,0 +1,28 @@
+import { Container, Typography } from "@mui/material"
+import { useEffect, useState } from "react"
+
+import { getModels } from "@/src/actions/models"
+import ModelCard from "@/src/components/ModelCard"
+
+export default function ModelList() {
+    const [models, setModels] = useState([])
+
+    useEffect(() => {
+        getModels().then(result => {
+            setModels(result.models)
+        })
+    }, [])
+
+    return (
+        <Container maxWidth={"md"}>
+            <Typography variant="h4" component="h1" gutterBottom>
+                Cloudflare Available Models
+            </Typography>
+            <div className={"flex flex-wrap gap-4"}>
+                {models.map((model) => (
+                    <ModelCard key={model.id} model={model} />
+                ))}
+            </div>
+        </Container>
+    )
+}

--- a/code-review-admin/src/utils/models.ts
+++ b/code-review-admin/src/utils/models.ts
@@ -1,0 +1,10 @@
+export interface Model {
+    id: string
+    name: string
+    description: string
+    task: {
+        id: string
+        name: string
+        description: string
+    }
+}


### PR DESCRIPTION
Add new functionality to display Cloudflare available models and update existing routes.

* **New Components and Pages**
  - Add `ModelsPage` component to display models fetched from the API.
  - Add `ModelCard` component to display individual model details using MUI `Card`.
  - Add `ModelList` component to display a list of models using `ModelCard`.

* **Server Actions**
  - Add `getModels` function in `models.ts` to fetch models from the API with query options.

* **Utilities**
  - Add `Model` interface in `models.ts` to define the structure of a model.

* **Layout and Navigation**
  - Update `layout.tsx` to include navigation links for "/" and "/models" routes.
  - Update `page.tsx` to show only the prompt list.

