### PR TITLE
Add tasks public API to worker

### DIFF
--- a/worker/src/api/tasks.schema.ts
+++ b/worker/src/api/tasks.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const TaskSchema = z.object({
+  id: z.string().openapi({ description: "ID", example: "c329a1f9-323d-4e91-b2aa-582dd4188d34" }),
+  name: z.string().openapi({ description: "Name", example: "Text Generation" }),
+  description: z.string().openapi({ description: "Description", example: "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks." })
+})
+
+export const TasksResponseSchema = z.object({
+  tasks: z.array(TaskSchema).openapi({ description: "List of tasks" })
+})

--- a/worker/src/api/tasks.ts
+++ b/worker/src/api/tasks.ts
@@ -1,0 +1,31 @@
+import { Hono } from "hono"
+import { describeRoute } from "hono-openapi"
+import { resolver } from "hono-openapi/zod"
+
+import { cloudflare } from "../utils/cloudflare"
+import { TasksResponseSchema } from "./tasks.schema"
+
+const tasks = new Hono<{ Bindings: CloudflareEnv }>()
+
+tasks.get("/",
+    describeRoute({
+        description: "List all tasks",
+        responses: {
+            200: {
+                content: {
+                    "application/json": {
+                        schema: resolver(TasksResponseSchema)
+                    }
+                }
+            }
+        }
+    }),
+    async (c) => {
+        const response = await cloudflare(c).ai.tasks.list({ account_id: c.env.ACCOUNT_ID })
+        const { result } = response
+
+        return c.json({ tasks: result })
+    }
+)
+
+export default tasks

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -8,6 +8,7 @@ import codeReview from "./api/code-review"
 import health from "./api/health"
 import models from "./api/models"
 import prompts from "./api/prompts"
+import tasks from "./api/tasks"
 import auth from "./middleware/auth"
 
 const app = new Hono<{ Bindings: CloudflareEnv }>()
@@ -15,9 +16,10 @@ const app = new Hono<{ Bindings: CloudflareEnv }>()
 app.route("/", auth)
 app.route("/health", health)
 
-app.route("/api/code-review", codeReview)
 app.route("/api/public/models", models)
+app.route("/api/public/tasks", tasks)
 app.route("/api/prompts", prompts)
+app.route("/api/code-review", codeReview)
 
 const appName = "Cloudflare AI code review worker"
 


### PR DESCRIPTION
Add a new public API endpoint for tasks (AI model categories).

* **Define Schemas**:
  - Add `TaskSchema` and `TasksResponseSchema` in `worker/src/api/tasks.schema.ts` using `zod`.

* **Create Tasks API**:
  - Add `worker/src/api/tasks.ts` to define a new `Hono` instance for tasks.
  - Define a GET route to list all tasks using `TasksResponseSchema`.
  - Call Cloudflare API `client.AI.Tasks.List`.

* **Update Main API Routes**:
  - Import the new `tasks` route in `worker/src/index.ts`.
  - Add a new route for `/api/public/tasks`.

