### PR TITLE
Encapsulate TaskCategorySelect as a component

### DIFF
--- a/code-review-admin/src/actions/tasks.ts
+++ b/code-review-admin/src/actions/tasks.ts
@@ -1,0 +1,5 @@
+"use server"
+
+export const getTasks = async () => {
+    return fetch(`${process.env.API_URL}/api/public/tasks`).then(res => res.json())
+}

--- a/code-review-admin/src/components/ModelList.tsx
+++ b/code-review-admin/src/components/ModelList.tsx
@@ -4,11 +4,12 @@ import type { KeyboardEventHandler} from "react"
 
 import SearchIcon from "@mui/icons-material/Search"
 import { IconButton } from "@mui/material"
-import { FormControl, InputLabel, MenuItem, Pagination, Select, TextField } from "@mui/material"
+import { TextField } from "@mui/material"
 import { useEffect, useState } from "react"
 
 import { getModels } from "@/src/actions/models"
 import ModelCard from "@/src/components/ModelCard"
+import TaskCategorySelect from "@/src/components/TaskCategorySelect"
 import type { Model } from "@/src/utils/models"
 
 export default function ModelsList() {
@@ -31,31 +32,13 @@ export default function ModelsList() {
         if (event.key === "Enter") fireSearch()
     }
 
-    const handleTaskNameChange = (event: SelectChangeEvent) => {
-        setTaskName(event.target.value)
-    }
-
     const handlePageChange = (_: unknown, value: number) => {
         setPage(value)
     }
     return (
         <>
             <div className={"flex items-center gap-2"}>
-                <FormControl variant={"outlined"} size={"small"}>
-                    <InputLabel>Category</InputLabel>
-                    <Select
-                        variant={"outlined"}
-                        value={taskName}
-                        label={"Category"}
-                        size={"small"}
-                        onChange={handleTaskNameChange}
-                        style={{ width: "200px" }}
-                    >
-                        <MenuItem value=""><em>None</em></MenuItem>
-                        <MenuItem value="task1">Task 1</MenuItem>
-                        <MenuItem value="task2">Task 2</MenuItem>
-                    </Select>
-                </FormControl>
+                <TaskCategorySelect taskName={taskName} onTaskNameSelect={setTaskName} />
                 <TextField
                     label="Press Enter to search"
                     value={search}

--- a/code-review-admin/src/components/TaskCategoryItems.tsx
+++ b/code-review-admin/src/components/TaskCategoryItems.tsx
@@ -1,0 +1,16 @@
+import { MenuItem } from "@mui/material"
+import { getTasks } from "@/src/actions/tasks"
+
+const TaskCategoryItems = async () => {
+    const tasks = await getTasks()
+
+    return (
+        <>
+            {tasks.map(task => (
+                <MenuItem key={task.id} value={task.name}>{task.name}</MenuItem>
+            ))}
+        </>
+    )
+}
+
+export default TaskCategoryItems

--- a/code-review-admin/src/components/TaskCategorySelect.tsx
+++ b/code-review-admin/src/components/TaskCategorySelect.tsx
@@ -1,0 +1,32 @@
+import { FormControl, InputLabel, Select, SelectChangeEvent } from "@mui/material"
+
+import TaskCategoryItems from "@/src/components/TaskCategoryItems"
+
+type TaskCategorySelectProps = {
+    taskName: string
+    onTaskNameSelect: (taskName: string) => void
+}
+
+const TaskCategorySelect = ({ taskName, onTaskNameSelect }: TaskCategorySelectProps) => {
+    const handleChange = (event: SelectChangeEvent) => {
+        onTaskNameSelect(event.target.value)
+    }
+
+    return (
+        <FormControl variant={"outlined"} size={"small"}>
+            <InputLabel>Category</InputLabel>
+            <Select
+                variant={"outlined"}
+                value={taskName}
+                label={"Category"}
+                size={"small"}
+                onChange={handleChange}
+                style={{ width: "200px" }}
+            >
+                <TaskCategoryItems />
+            </Select>
+        </FormControl>
+    )
+}
+
+export default TaskCategorySelect


### PR DESCRIPTION
Encapsulate Task Name select as a component.

* **Add TaskCategorySelect component**
  - Create `TaskCategorySelect.tsx` to accept `taskName` and `onTaskNameSelect` props.
  - Use `TaskCategoryItems` to display tasks as `MenuItem` components.
  - Export the component as default.

* **Add TaskCategoryItems component**
  - Create `TaskCategoryItems.tsx` to fetch tasks using the tasks API.
  - Display tasks as `MenuItem` components.
  - Export the component as default.

* **Modify ModelList component**
  - Replace the existing `Select` component with `TaskCategorySelect`.
  - Pass `taskName` and `onTaskNameSelect` props to `TaskCategorySelect`.

* **Add tasks API action**
  - Create `tasks.ts` to fetch tasks from the API.

