### PR TITLE
Update api/github/webhook to reply with 'hello' on new comment

### DIFF
--- a/worker/src/api/github.ts
+++ b/worker/src/api/github.ts
@@ -21,17 +21,23 @@ github.post("/webhook", async (c) => {
 
     const body = await c.req.json()
     console.log("body action", body.action)
-    app.webhooks.on("issue_comment.created", async ({ octokit, payload }) => {
-        console.log("issues.opened", payload)
+
+    if (body.action === "issue_comment.created") {
+        const { octokit, payload } = await app.webhooks.receive({
+            id: c.req.header("x-github-delivery")!,
+            name: "issue_comment",
+            payload: body
+        })
+        console.log("issue_comment.created", payload)
         await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
             {
                 owner: payload.repository.owner.login,
                 repo: payload.repository.name,
                 issue_number: payload.issue.number,
-                body: "Hello there from [octokit](https://github.com/octokit/app.js/)"
+                body: "hello"
             }
         )
-    })
+    }
 
     if (body.action === "opened" && body.issue) {
         return c.json({ message: "Welcome! Issue created." })


### PR DESCRIPTION
Update the GitHub webhook to support replying with "hello" when a new comment is submitted.

* Add a new event handler for `issue_comment.created` to reply with "hello"
* Remove the existing `issue_comment.created` event handler
* Update the `body` of the reply message to "hello"

