### PR TITLE
Finish the issue_comment.create handler

### DIFF
--- a/worker/src/api/github.ts
+++ b/worker/src/api/github.ts
@@ -20,7 +20,7 @@ github.post("/webhook", async (c) => {
 
     const payload = await c.req.json()
 
-    if (GitHubWebHook.isIssueCommentCreated(payload)) await GitHubWebHook.issueCommentCreatedHandler(app, payload)
+    if (GitHubWebHook.isIssueCommentCreated(payload)) await GitHubWebHook.issueCommentCreatedHandler(c, app, payload)
 
     if (payload.action === "opened" && payload.issue) {
         return c.json({ message: "Welcome! Issue created." })


### PR DESCRIPTION
Add handling for issue comments starting with a slash command.

* **Add context parameter**: Add a new parameter `ctx` of type `Context<{ Bindings: CloudflareEnv }>` to the `issueCommentCreatedHandler` function.
* **Extract and check command**: Check if the comment starts with a slash `/` and extract the command.
* **Check Cloudflare KV**: Check if the Cloudflare KV has a key equal to the extracted command.
* **Commit new comment**: If the key exists, commit a new comment with the message "hello match the command xxx". If the key does not exist, commit a new comment with the message "hello, xxx command not supported yet".
* **Pass context parameter**: Pass the `ctx` parameter to the `issueCommentCreatedHandler` function when calling it in `github.ts`.

