### PR TITLE
Add feature to import prompts from JSON file

### DIFF
--- a/code-review-admin/src/components/PromptList.tsx
+++ b/code-review-admin/src/components/PromptList.tsx
@@ -3,11 +3,12 @@ import DownloadIcon from "@mui/icons-material/Download"
 import { Button } from "@mui/material"
 import { useEffect, useState } from "react"
 
-import { getPrompts } from "@/src/actions/prompts"
+import { getPrompts, importPrompts } from "@/src/actions/prompts"
 import ModifyPromptDialog from "@/src/components/ModifyPromptDialog"
 import PromptCard from "@/src/components/PromptCard"
 import type { Prompt } from "@/src/utils/api"
 import { downloadPrompts } from "@/src/utils/downloadPrompts"
+
 const PromptList = () => {
     const [prompts, setPrompts] = useState<Prompt[]>([])
     const [open, setOpen] = useState(false)
@@ -28,11 +29,29 @@ const PromptList = () => {
         downloadPrompts(prompts)
     }
 
+    const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+        if (file) {
+            const reader = new FileReader()
+            reader.onload = async (e) => {
+                const content = e.target?.result as string
+                const importedPrompts = JSON.parse(content)
+                await importPrompts(importedPrompts)
+                refreshList()
+            }
+            reader.readAsText(file)
+        }
+    }
+
     return (
         <div style={{ height: "calc(100% - 40px)" }}>
             <div className={"flex gap-2"}>
                 <Button onClick={handleOpen}>Add Prompt</Button>
                 <Button startIcon={<DownloadIcon />} color={"inherit"} onClick={handleDownload}>Download Prompts</Button>
+                <Button component="label" color={"inherit"}>
+                    Import Prompts
+                    <input type="file" accept=".json" hidden onChange={handleImport} />
+                </Button>
             </div>
             <div className={"flex flex-col gap-4 px-1 -m-1 py-2 overflow-y-auto"}
                 style={{ height: "calc(100% - 31px)" }}>

--- a/code-review-admin/src/utils/api.ts
+++ b/code-review-admin/src/utils/api.ts
@@ -34,3 +34,8 @@ export const commonHeaders = {
     Authorization: `Bearer ${process.env.AUTH_TOKEN}`,
     "Content-Type": "application/json"
 }
+
+export interface ImportPromptsResponse {
+    success: boolean
+    message: string
+}


### PR DESCRIPTION
Add feature to import prompts from a local JSON file.

* **PromptList.tsx**
  - Import `importPrompts` from `actions/prompts`.
  - Add `handleImport` function to read the JSON file and call `importPrompts`.
  - Add a new button to handle importing prompts from a JSON file.
* **api.ts**
  - Add `ImportPromptsResponse` interface to handle the response from the import prompts API.

