### PR TITLE
Add --include-patch argument to retrive command

### DIFF
--- a/worker/src/api/handleArgumentIncludePatch.ts
+++ b/worker/src/api/handleArgumentIncludePatch.ts
@@ -1,0 +1,16 @@
+import { Octokit } from "@octokit/rest";
+
+const collectGithubPullRequestPatch = async (app: Octokit, payload: any): Promise<string> => {
+    const { data } = await app.pulls.get({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        pull_number: payload.issue.number,
+        mediaType: {
+            format: "diff"
+        }
+    });
+
+    return data as unknown as string;
+};
+
+export default collectGithubPullRequestPatch;

--- a/worker/src/api/handleCommandName.ts
+++ b/worker/src/api/handleCommandName.ts
@@ -1,0 +1,26 @@
+import type { Prompt } from "./prompts.schema"
+import type { NotVerifiedAIResponse } from "./webhook-handlers/issue_comment.created"
+
+export const prepareCommandPrompts = async (
+    ctx: Context<{ Bindings: CloudflareEnv }>,
+    command: string,
+    commentLines: string[],
+    prompt: Prompt
+): Promise<string> => {
+    const messages = [...prompt.messages]
+
+    if (commentLines.length) messages.push({ role: "user", content: commentLines.join("\n")})
+
+    const output = await ctx.env.AI.run(prompt.model as "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b", {
+        messages,
+        stream: false
+    }) as NotVerifiedAIResponse
+
+    let message = output.response
+    message += "\nToken usage:"
+    message += `\n-Prompt: ${output.usage.prompt_token}`
+    message += `\n-Completion: ${output.usage.completion_token}`
+    message += `\n-Total: ${output.usage.total_tokens}`
+
+    return message
+}


### PR DESCRIPTION
Add support for `--include-patch` argument to the `issue_comment.created` webhook handler.

* **New Functionality**
  - Create `handleArgumentIncludePatch.ts` to collect GitHub pull request patch.
  - Export `collectGithubPullRequestPatch` function to fetch pull request patch using Octokit.

* **Refactor and Integration**
  - Create `handleCommandName.ts` and move old concat prompts logic to `prepareCommandPrompts`.
  - Update `issue_comment.created.ts` to import `prepareCommandPrompts` and `collectGithubPullRequestPatch`.
  - Modify command parsing to handle arguments.
  - Add logic to include commit patch in user role message if `--include-patch` argument is present.

